### PR TITLE
Fix error where `leap_year.rb` cannot be loaded 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,3 @@ DEPENDENCIES
   middleman-syntax (= 2.0.0)
   middleman-toc
   redcarpet
-
-BUNDLED WITH
-   1.12.5

--- a/source/02-testing/02-separation.md
+++ b/source/02-testing/02-separation.md
@@ -29,7 +29,7 @@ $ ruby -I -r leap_year.rb -e "p leap_year?(1996)"
 true
 ```
 
-The flag `-r` tells Ruby to require your file. The flag `-I` tells it where to look in the current directory to load the file. The flag `-e` tells it to
+The flag `-r` tells Ruby to require your file. The flag `-I` tells it to look in the current directory to load the file. The flag `-e` tells it to
 execute the given code.  This way you don't have to create a new file in order
 to try this out.
 

--- a/source/02-testing/02-separation.md
+++ b/source/02-testing/02-separation.md
@@ -29,9 +29,7 @@ $ ruby -I -r leap_year.rb -e "p leap_year?(1996)"
 true
 ```
 
-The flag `-r` tells Ruby to require your file. The flag `-I` tells it to look in the current directory to load the file. The flag `-e` tells it to
-execute the given code.  This way you don't have to create a new file in order
-to try this out.
+The flag `-r` tells Ruby to require your file. The flag `-I` tells it to look in the current directory to load the file. The flag `-e` tells it to execute the given code.  This way you don't have to create a new file in order to try this out.
 
 As you can see it now won't execute your "test", and thus won't output `2004:
 true` again.

--- a/source/02-testing/02-separation.md
+++ b/source/02-testing/02-separation.md
@@ -25,12 +25,12 @@ else) then you would not get this output.
 You can try this out quickly on the command line:
 
 ```
-$ ruby -r leap_year.rb -e "p leap_year?(1996)"
+$ ruby -I -r leap_year.rb -e "p leap_year?(1996)"
 true
 ```
 
-The flag `-r` tells Ruby to require your file. The flag `-e` tells it to
-execute the given code. This way you don't have to create a new file in order
+The flag `-r` tells Ruby to require your file. The flag `-I` tells it where to look in the current directory to load the file. The flag `-e` tells it to
+execute the given code.  This way you don't have to create a new file in order
 to try this out.
 
 As you can see it now won't execute your "test", and thus won't output `2004:

--- a/source/02-testing/02-separation.md
+++ b/source/02-testing/02-separation.md
@@ -29,7 +29,9 @@ $ ruby -I -r leap_year.rb -e "p leap_year?(1996)"
 true
 ```
 
-The flag `-r` tells Ruby to require your file. The flag `-I` tells it to look in the current directory to load the file. The flag `-e` tells it to execute the given code.  This way you don't have to create a new file in order to try this out.
+The flag `-r` tells Ruby to require your file. The flag `-I` tells it to look 
+in the current directory to load the file. The flag `-e` tells it to execute 
+the given code.  This way you don't have to create a new file in order to try this out.
 
 As you can see it now won't execute your "test", and thus won't output `2004:
 true` again.


### PR DESCRIPTION
Fixes this bug: https://github.com/rubymonsters/testing-for-beginners/issues/3
